### PR TITLE
Adjust documentation to make it easier to view in perlnavigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,25 @@ This module does not wrap a return value in an object. Just return a tuple like 
 
 ### Ok
 
-```perl
-Ok($data)
-# => ($data, undef)
-```
-
 Return a tuple of a given value and undef. When the function succeeds, it should return this.
+
+```perl
+sub add($a, $b) {
+    Ok($a + $b); # => ($a + $b, undef)
+}
+```
 
 ### Err
 
+Return a tuple of undef and a given error. When the function fails, it should return this.
+
 ```perl
-Err($err)
-# => (undef, $err)
+sub div($a, $b) {
+    return Err('Division by zero') if $b == 0; # => (undef, 'Division by zero')
+    Ok($a / $b);
+}
 ```
 
-Return a tuple of undef and a given error. When the function fails, it should return this.
 Note that the error value must be a truthy value, otherwise it will throw an exception.
 
 ## ATTRIBUTES
@@ -153,7 +157,7 @@ This option is useful for development and testing mode, and it recommended to se
 
 # NOTE
 
-## What happens when you forget to call `Ok` or `Err`?
+## Avoiding Ambiguity in Result Handling
 
 Forgetting to call `Ok` or `Err` function is a common mistake. Consider the following example:
 

--- a/lib/Result/Simple.pm
+++ b/lib/Result/Simple.pm
@@ -202,17 +202,21 @@ This module does not wrap a return value in an object. Just return a tuple like 
 
 =head3 Ok
 
-    Ok($data)
-    # => ($data, undef)
-
 Return a tuple of a given value and undef. When the function succeeds, it should return this.
+
+    sub add($a, $b) {
+        Ok($a + $b); # => ($a + $b, undef)
+    }
 
 =head3 Err
 
-    Err($err)
-    # => (undef, $err)
-
 Return a tuple of undef and a given error. When the function fails, it should return this.
+
+    sub div($a, $b) {
+        return Err('Division by zero') if $b == 0; # => (undef, 'Division by zero')
+        Ok($a / $b);
+    }
+
 Note that the error value must be a truthy value, otherwise it will throw an exception.
 
 =head2 ATTRIBUTES
@@ -274,7 +278,7 @@ This option is useful for development and testing mode, and it recommended to se
 
 =head1 NOTE
 
-=head2 What happens when you forget to call C<Ok> or C<Err>?
+=head2 Avoiding Ambiguity in Result Handling
 
 Forgetting to call C<Ok> or C<Err> function is a common mistake. Consider the following example:
 


### PR DESCRIPTION
This pull request is for better visibility in [perlnavigator](https://github.com/bscan/PerlNavigator).

### Ok
<img width="600" alt="image" src="https://github.com/user-attachments/assets/5a9a8a9b-6ca8-4f94-b327-cdf4091e3783">

### Err

<img width="600" alt="image" src="https://github.com/user-attachments/assets/2894d7e4-cf11-407d-89cb-d55426368f7c">


