### PR TITLE
[BREAKING CHANGES] Rename `Ok`,`Err` and Remove :Result attribute and more.

### DIFF
--- a/META.json
+++ b/META.json
@@ -42,6 +42,7 @@
       },
       "runtime" : {
          "requires" : {
+            "Exporter::Tiny" : "0",
             "Scope::Upper" : "0",
             "Sub::Util" : "0",
             "perl" : "5.014004"

--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.014004';
 
 requires 'Scope::Upper';
 requires 'Sub::Util';
+requires 'Exporter::Tiny';
 
 on 'configure' => sub {
     requires 'Module::Build::Tiny', '0.035';

--- a/lib/Result/Simple.pm
+++ b/lib/Result/Simple.pm
@@ -300,6 +300,8 @@ When a function never returns an error, you can set type E to C<undef>:
     result_for bar => Int, undef;
     sub double ($n) { ok($n * 2) }
 
+=back
+
 =head3 unsafe_unwrap($data, $err)
 
 C<unsafe_unwrap> takes a Result<T, E> and returns a T when the result is an Ok, otherwise it throws exception.
@@ -309,8 +311,6 @@ It should be used in tests or debugging code.
 
 C<unsafe_unwrap_err> takes a Result<T, E> and returns an E when the result is an Err, otherwise it throws exception.
 It should be used in tests or debugging code.
-
-=back
 
 Note that types require C<check> method that returns true or false. So you can use your favorite type constraint module like
 L<Type::Tiny>, L<Moose>, L<Mouse> or L<Data::Checks> etc.

--- a/lib/Result/Simple.pm
+++ b/lib/Result/Simple.pm
@@ -14,8 +14,8 @@ use Sub::Util ();
 use Scalar::Util ();
 
 # If this option is true, then check `ok` and `err` functions usage and check a return value type.
-# However, it should be falsy for production code, because of performance and it is an assertion, not a validation.
-use constant CHECK_ENABLED => $ENV{RESULT_SIMPLE_CHECK_ENABLED} // 0;
+# However, it should be falsy for production code, because of performance, and it is an assertion, not a validation.
+use constant CHECK_ENABLED => $ENV{RESULT_SIMPLE_CHECK_ENABLED} // 1;
 
 # err does not allow these values.
 use constant FALSY_VALUES => [0, '0', '', undef];
@@ -150,11 +150,8 @@ Result::Simple - A dead simple perl-ish Result like F#, Rust, Go, etc.
 
 =head1 SYNOPSIS
 
-    # Enable type check. The default is false.
-    BEGIN { $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 1 }
-
     use Test2::V0;
-    use Result::Simple;
+    use Result::Simple qw(ok err result_for);
     use Types::Common -types;
 
     use kura ErrorMessage => StrLength[3,];
@@ -178,7 +175,9 @@ Result::Simple - A dead simple perl-ish Result like F#, Rust, Go, etc.
         return ok($age);
     }
 
-    sub new_user :Result(ValidUser, ArrayRef[ErrorMessage]) {
+    result_for new_user => ValidUser, ArrayRef[ErrorMessage];
+
+    sub new_user {
         my $args = shift;
         my @errors;
 
@@ -273,20 +272,14 @@ L<Type::Tiny>, L<Moose>, L<Mouse> or L<Data::Checks> etc.
 =head3 C<$ENV{RESULT_SIMPLE_CHECK_ENABLED}>
 
 If the C<ENV{RESULT_SIMPLE_CHECK_ENABLED}> environment is truthy before loading this module, it works as an assertion.
-Otherwise, if it is falsy, C<:Result(T, E)> attribute does nothing. The default is false.
-
-    sub invalid :Result(Int, undef) { ok("hello") }
-
-    my ($data, $err) = invalid();
-    # => throw exception when check enabled
-    # => no exception when check disabled
-
-The following code is an example to enable it:
-
-    BEGIN { $ENV{RESULT_SIMPLE_CHECK_ENABLED} = is_test ? 1 : 0 }
-    use Result::Simple;
-
+Otherwise, if it is falsy, C<result_for> attribute does nothing. The default is true.
 This option is useful for development and testing mode, and it recommended to set it to false for production.
+
+    result_for foo => Int, undef;
+    sub foo { ok("hello") }
+
+    my ($data, $err) = foo();
+    # => throw exception when check enabled
 
 =head1 NOTE
 

--- a/lib/Result/Simple.pm
+++ b/lib/Result/Simple.pm
@@ -4,9 +4,7 @@ use warnings;
 
 our $VERSION = "0.03";
 
-use Exporter 'import';
-
-our @EXPORT_OK = qw(
+use Exporter::Shiny qw(
     ok
     err
     result_for
@@ -363,6 +361,17 @@ Here, the function returns a valid failure tuple C<(undef, $err)>. However, it i
 The lack of C<ok> or C<err> makes the intent ambiguous.
 
 Conclusively, be sure to use C<ok> or C<err> functions to make it clear whether the success or failure is intentional.
+
+=head2 Use alias name
+
+You can use alias name for C<ok> and C<err> functions like this:
+
+    use Result::Simple
+        ok => { -as => 'left' },
+        err => { -as => 'right' };
+
+    left('foo'); # => ('foo', undef)
+    right('bar'); # => (undef, 'bar')
 
 =head1 LICENSE
 

--- a/t/Result-Simple.t
+++ b/t/Result-Simple.t
@@ -4,7 +4,7 @@ Test the Result::Simple module with CHECK_ENABLED is truthy.
 
 =cut
 
-use Test2::V0;
+use Test2::V0 qw(subtest is like unlike dies done_testing);
 
 use lib "t/lib";
 use TestType qw( Int NonEmptyStr );
@@ -13,52 +13,64 @@ BEGIN {
     $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 1;
 }
 
-use Result::Simple;
+use Result::Simple qw( ok err result_for );
 
-subtest 'Test `Ok` and `Err` functions' => sub {
-    subtest '`Ok` and `Err` functions just return values' => sub {
-        my ($data, $err) = Ok('foo');
+subtest 'Test `ok` and `err` functions' => sub {
+    subtest '`ok` and `err` functions just return values' => sub {
+        my ($data, $err) = ok('foo');
         is $data, 'foo';
         is $err, undef;
 
-        ($data, $err) = Err('bar');
+        ($data, $err) = err('bar');
         is $data, undef;
         is $err, 'bar';
     };
 
-    subtest '`Ok` and `Err` must be called in list context' => sub {
-        like dies { my $data = Ok('foo') }, qr/`Ok` must be called in list context/;
-        like dies { my $err = Err('bar') }, qr/`Err` must be called in list context/;
+    subtest '`ok` and `err` must be called in list context' => sub {
+        like dies { my $data = ok('foo') }, qr/`ok` must be called in list context/;
+        like dies { my $err = err('bar') }, qr/`err` must be called in list context/;
     };
 
-    subtest '`Ok` and `Err` does not allow multiple arguments' => sub {
-        like dies { my ($data, $err) = Ok('foo', 'bar') }, qr/`Ok` does not allow multiple arguments/;
-        like dies { my ($data, $err) = Err('bar', 'foo') }, qr/`Err` does not allow multiple arguments/;
+    subtest '`ok` and `err` does not allow multiple arguments' => sub {
+        like dies { my ($data, $err) = ok('foo', 'bar') }, qr/`ok` does not allow multiple arguments/;
+        like dies { my ($data, $err) = err('bar', 'foo') }, qr/`err` does not allow multiple arguments/;
     };
 
-    subtest '`Ok` and `Err` does not allow no arguments' => sub {
-        like dies { my ($data, $err) = Ok() }, qr/`Ok` does not allow no arguments/;
-        like dies { my ($data, $err) = Err() }, qr/`Err` does not allow no arguments/;
+    subtest '`ok` and `err` does not allow no arguments' => sub {
+        like dies { my ($data, $err) = ok() }, qr/`ok` does not allow no arguments/;
+        like dies { my ($data, $err) = err() }, qr/`err` does not allow no arguments/;
     };
 
-    subtest '`Err` does not allow falsy values' => sub {
-        like dies { my ($data, $err) = Err(0) }, qr/`Err` does not allow a falsy value: 0/;
-        like dies { my ($data, $err) = Err('0') }, qr/`Err` does not allow a falsy value: '0'/;
-        like dies { my ($data, $err) = Err('') }, qr/`Err` does not allow a falsy value: ''/;
+    subtest '`err` does not allow falsy values' => sub {
+        like dies { my ($data, $err) = err(0) }, qr/`err` does not allow a falsy value: 0/;
+        like dies { my ($data, $err) = err('0') }, qr/`err` does not allow a falsy value: '0'/;
+        like dies { my ($data, $err) = err('') }, qr/`err` does not allow a falsy value: ''/;
     };
 };
 
-subtest 'Test :Result attribute' => sub {
+subtest 'Test `result_for` function' => sub {
     # valid cases
-    sub valid :Result(Int, NonEmptyStr) { Ok(42) }
-    sub no_error :Result(Int, undef) { Ok(42) }
+    result_for valid => Int, NonEmptyStr;
+    sub valid { ok(42) }
+
+    result_for no_error => Int, undef;
+    sub no_error { ok(42) }
 
     # invalid cases
-    sub invalid_ok_type :Result(Int, NonEmptyStr) { Ok('foo') }
-    sub invalid_err_type :Result(Int, NonEmptyStr) { Err(\1) }
-    sub a_few_result :Result(Int, NonEmptyStr) { 'foo' }
-    sub too_many_result :Result(Int, NonEmptyStr) { (1,2,3) }
-    sub never_return_error :Result(Int, undef) { Err('foo') }
+    result_for invalid_ok_type => Int, NonEmptyStr;
+    sub invalid_ok_type { ok('foo') }
+
+    result_for invalid_err_type => Int, NonEmptyStr;
+    sub invalid_err_type { err(\1) }
+
+    result_for a_few_result => Int, NonEmptyStr;
+    sub a_few_result { 'foo' }
+
+    result_for too_many_result => Int, NonEmptyStr;
+    sub too_many_result { (1,2,3) }
+
+    result_for never_return_error => Int, undef;
+    sub never_return_error { err('foo') }
 
     subtest 'When a return value satisfies the Result type (T, E), then return the value' => sub {
         my ($data, $err) = valid();
@@ -75,8 +87,8 @@ subtest 'Test :Result attribute' => sub {
     subtest 'When a return value does not satisfy the Result type (T, E), then throw a exception' => sub {
         like dies { my ($data, $err) = invalid_ok_type() },    qr!Invalid success result in `invalid_ok_type`: \['foo',undef\]!;
         like dies { my ($data, $err) = invalid_err_type() },   qr!Invalid failure result in `invalid_err_type`: \[undef,\\1\]!;
-        like dies { my ($data, $err) = a_few_result() },       qr!Invalid result tuple \(T, E\) in `a_few_result`. Do you forget to call `Ok` or `Err` function\? Got: \['foo'\]!;
-        like dies { my ($data, $err) = too_many_result() },    qr!Invalid result tuple \(T, E\) in `too_many_result`. Do you forget to call `Ok` or `Err` function\? Got: \[1,2,3\]!;
+        like dies { my ($data, $err) = a_few_result() },       qr!Invalid result tuple \(T, E\) in `a_few_result`. Do you forget to call `ok` or `err` function\? Got: \['foo'\]!;
+        like dies { my ($data, $err) = too_many_result() },    qr!Invalid result tuple \(T, E\) in `too_many_result`. Do you forget to call `ok` or `err` function\? Got: \[1,2,3\]!;
         like dies { my ($data, $err) = never_return_error() }, qr!Never return error in `never_return_error`: \[undef,'foo'\]!;
     };
 
@@ -84,43 +96,47 @@ subtest 'Test :Result attribute' => sub {
         like dies { my $result = valid() }, qr/Must handle error in `valid`/;
     };
 
-    subtest 'Result(T, E) requires `check` method' => sub {
-        eval "sub invalid_type_T :Result('HELLO', NonEmptyStr) { Ok('HELLO') }";
-        like $@, qr/Result T requires `check` method/;
+    subtest '(T, E) requires `check` method' => sub {
+        sub invalid_type_T { ok(42) };
+        like dies { result_for invalid_type_T => 'Hello', NonEmptyStr }, qr!result_for T requires `check` method!;
 
-        eval "sub invalid_type_E :Result(Int, 'WORLD') { Err('WORLD') }";
-        like $@, qr/Result E requires `check` method/;
+        sub invalid_type_E { err(42) };
+        like dies { result_for invalid_type_E => Int, 'World' }, qr!result_for E requires `check` method!;
     };
 
     subtest 'E should not allow falsy values' => sub {
-        eval "sub should_not_allow_falsy :Result(Int, Int) { }";
-        like $@, qr/Result E should not allow falsy values: \[0,'0'\]/;
-    };
-};
-
-subtest 'Test the details of :Result attribute' => sub {
-    subtest 'Useful stacktrace' => sub {
-        sub test_stacktrace :Result(Int, NonEmptyStr) { Carp::confess('hello') }
-
-        eval { my ($data, $err) = test_stacktrace() };
-
-        my $file = __FILE__;
-        like $@, qr!hello at $file line!;
-        like $@, qr/main::test_stacktrace\(\) called at $file line /, 'stacktrace includes function name';
-        unlike $@, qr/Result::Simple::/, 'stacktrace does not include Result::Simple by Scope::Upper';
+        sub should_not_allow_falsy { err(0) };
+        like dies { result_for should_not_allow_falsy => Int, Int }, qr/result_for E should not allow falsy values: \[0,'0'\]/;
     };
 
-    subtest 'Same subname and prototype as original' => sub {
-        sub same (;$) :Result(Int, NonEmptyStr) { Ok(42) }
+    subtest 'Test the details of `retsult_for` function' => sub {
+        subtest 'Useful stacktrace' => sub {
 
-        my $code = \&same;
+            result_for test_stacktrace => Int, NonEmptyStr;
+            sub test_stacktrace { Carp::confess('hello') }
 
-        require Sub::Util;
-        my $name = Sub::Util::subname($code);
-        is $name, 'main::same';
+            eval { my ($data, $err) = test_stacktrace() };
 
-        my $proto = Sub::Util::prototype($code);
-        is $proto, ';$';
+            my $file = __FILE__;
+            like $@, qr!hello at $file line!;
+            like $@, qr/main::test_stacktrace\(\) called at $file line /, 'stacktrace includes function name';
+            unlike $@, qr/Result::Simple::/, 'stacktrace does not include Result::Simple by Scope::Upper';
+        };
+
+        subtest 'Same subname and prototype as original' => sub {
+
+            result_for same => Int, NonEmptyStr;
+            sub same (;$) { ok(42) }
+
+            my $code = \&same;
+
+            require Sub::Util;
+            my $name = Sub::Util::subname($code);
+            is $name, 'main::same';
+
+            my $proto = Sub::Util::prototype($code);
+            is $proto, ';$';
+        };
     };
 };
 

--- a/t/Result-Simple.t
+++ b/t/Result-Simple.t
@@ -10,7 +10,8 @@ use lib "t/lib";
 use TestType qw( Int NonEmptyStr );
 
 BEGIN {
-    $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 1;
+    # Enable type check. The default is true.
+    # $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 1;
 }
 
 use Result::Simple qw( ok err result_for );

--- a/t/Result-Simple.t
+++ b/t/Result-Simple.t
@@ -138,6 +138,10 @@ subtest 'Test `result_for` function' => sub {
             my $proto = Sub::Util::prototype($code);
             is $proto, ';$';
         };
+
+        subtest 'When function is not found, then throw a exception' => sub {
+            like dies { result_for xxx => Int, NonEmptyStr } => qr/result_for: function `xxx` not found/;
+        };
     };
 };
 

--- a/t/Result-Simple.t
+++ b/t/Result-Simple.t
@@ -14,7 +14,7 @@ BEGIN {
     # $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 1;
 }
 
-use Result::Simple qw( ok err result_for );
+use Result::Simple qw( ok err result_for unsafe_unwrap unsafe_unwrap_err );
 
 subtest 'Test `ok` and `err` functions' => sub {
     subtest '`ok` and `err` functions just return values' => sub {
@@ -140,5 +140,27 @@ subtest 'Test `result_for` function' => sub {
         };
     };
 };
+
+subtest 'Test `unsafe_unwrap` function' => sub {
+    subtest 'When ok() is called, then return the value' => sub {
+        my $got = unsafe_unwrap(ok(42));
+        is $got, 42;
+    };
+
+    subtest 'When err() is called, then throw a exception' => sub {
+        like dies { my ($data, $err) = unsafe_unwrap(err('foo')) }, qr/Error called in `unsafe_unwrap`/;
+    };
+};
+
+subtest 'Test `unsafe_unwrap_err` function' => sub {
+    subtest 'When ok() is called, then throw a exception' => sub {
+        like dies { my ($data, $err) = unsafe_unwrap_err(ok(42)) }, qr/No error called in `unsafe_unwrap_err`/;
+    };
+    subtest 'When err() is called, then return the value' => sub {
+        my $got = unsafe_unwrap_err(err('foo'));
+        is $got, 'foo';
+    };
+};
+
 
 done_testing;

--- a/t/alias.t
+++ b/t/alias.t
@@ -1,0 +1,17 @@
+=pod
+
+Test using alias names for Result::Simple functions.
+
+=cut
+
+use Test2::V0;
+
+use Result::Simple
+    ok => { -as => 'left' },
+    err => { -as => 'right' },
+    ;
+
+is [ left('foo') ], ['foo', undef ], 'ok() is aliased to success()';
+is [ right('bar') ], [undef, 'bar'], 'err() is aliased to failure()';
+
+done_testing;

--- a/t/check-disabled.t
+++ b/t/check-disabled.t
@@ -5,46 +5,52 @@ These tests are same cases as Result-Simple.t, but CHECK_ENABLED is falsy.
 
 =cut
 
-use Test2::V0;
+use Test2::V0 qw(subtest is like unlike lives done_testing);
+use Test2::V0 ok => { -as => 'test_ok' };
 
 use lib "t/lib";
 use TestType qw( Int NonEmptyStr );
 
 BEGIN {
-    # Default is falsy
-    # $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 0;
+    $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 0;
 }
 
-use Result::Simple;
+use Result::Simple qw( ok err result_for );
 
-subtest 'Test `Ok` and `Err` functions' => sub {
-    subtest '`Ok` and `Err` functions just return values' => sub {
-        my ($data, $err) = Ok('foo');
+subtest 'Test `ok` and `err` functions' => sub {
+    subtest '`ok` and `err` functions just return values' => sub {
+        my ($data, $err) = ok('foo');
         is $data, 'foo';
         is $err, undef;
 
-        ($data, $err) = Err('bar');
+        ($data, $err) = err('bar');
         is $data, undef;
         is $err, 'bar';
     };
 
-    subtest '`Ok` and `Err` must be called in list context, but when CHECK_ENABLED is falsy, then do not throw exception' => sub {
-        ok lives { my $data = Ok('foo') };
-        ok lives { my $err = Err('bar') };
+    subtest '`ok` and `err` must be called in list context, but when CHECK_ENABLED is falsy, then do not throw exception' => sub {
+        test_ok lives { my $data = ok('foo') };
+        test_ok lives { my $err = err('bar') };
     };
 
-    subtest '`Err` does not allow falsy values, but when CHECK_ENABLED is falsy, then do not throw exception' => sub {
-        ok lives { my ($data, $err) = Err() };
-        ok lives { my ($data, $err) = Err(0) };
-        ok lives { my ($data, $err) = Err('0') };
-        ok lives { my ($data, $err) = Err('') };
+    subtest '`err` does not allow falsy values, but when CHECK_ENABLED is falsy, then do not throw exception' => sub {
+        test_ok lives { my ($data, $err) = err() };
+        test_ok lives { my ($data, $err) = err(0) };
+        test_ok lives { my ($data, $err) = err('0') };
+        test_ok lives { my ($data, $err) = err('') };
     };
 };
 
-subtest 'Test :Result attribute' => sub {
-    sub valid : Result(Int, NonEmptyStr) { Ok(42) }
-    sub invalid_ok_type :Result(Int, NonEmptyStr) { Ok('foo') }
-    sub invalid_err_type :Result(Int, NonEmptyStr) { Err(\1) }
+subtest 'Test `result_for` function' => sub {
+
+    result_for valid => Int, NonEmptyStr;
+    sub valid { ok(42) }
+
+    result_for invalid_ok_type => Int, NonEmptyStr;
+    sub invalid_ok_type { ok('foo') }
+
+    result_for invalid_err_type => Int, NonEmptyStr;
+    sub invalid_err_type { err(\1) }
 
     subtest 'When a return value satisfies the Result type (T, E), then return the value' => sub {
         my ($data, $err) = valid();
@@ -53,53 +59,56 @@ subtest 'Test :Result attribute' => sub {
     };
 
     subtest 'When a return value does not satisfy the Result type (T, E), then throw a exception, but CHECK_ENABLED is falsy, then do not' => sub {
-        ok lives { my ($data, $err) = invalid_ok_type() };
-        ok lives { my ($data, $err) = invalid_err_type() };
+        test_ok lives { my ($data, $err) = invalid_ok_type() };
+        test_ok lives { my ($data, $err) = invalid_err_type() };
     };
 
     subtest 'Must handle error, but CHECK_ENABLED is falsy, then do not throw exception' => sub {
-        ok lives { my $result = valid() };
+        test_ok lives { my $result = valid() };
     };
 
     subtest 'Result(T, E) requires `check` method, but CHECK_ENABLED is falsy, then do not throw exception' => sub {
-        eval "sub invalid_type_T :Result('HELLO', NonEmptyStr) { Ok('HELLO') }";
-        is $@, '';
+        sub invalid_type_T { ok(42) };
+        test_ok lives { result_for invalid_type_T => 'Hello', NonEmptyStr };
 
-        eval "sub invalid_type_E :Result(Int, 'WORLD') { Err('WORLD') }";
-        is $@, '';
+        sub invalid_type_E { err(42) };
+        test_ok lives { result_for invalid_type_E => Int, 'World' };
     };
 
     subtest 'E should not allow falsy values, but CHECK_ENABLED is falsy, then do not throw exception' => sub {
-        eval "sub should_not_allow_falsy :Result(Int, Int) { }";
-        is $@, '';
-    };
-};
-
-subtest 'Test the details of :Result attribute' => sub {
-    note 'When CHECK_ENABLED is falsy, then do not wrap the original function';
-
-    subtest 'Useful stacktrace' => sub {
-        sub test_stacktrace :Result(Int, NonEmptyStr) { Carp::confess('hello') }
-
-        eval { my ($data, $err) = test_stacktrace() };
-
-        my $file = __FILE__;
-        like $@, qr!hello at $file line!;
-        like $@, qr/main::test_stacktrace\(\) called at $file line /, 'stacktrace includes function name';
-        unlike $@, qr/Result::Simple::/, 'stacktrace does not include Result::Simple by Scope::Upper';
+        sub should_not_allow_falsy { err(0) };
+        test_ok lives { result_for should_not_allow_falsy => Int, Int };
     };
 
-    subtest 'Same subname and prototype as original' => sub {
-        sub same (;$) :Result(Int, NonEmptyStr) { Ok(42) }
+    subtest 'Test the details of `retsult_for` function' => sub {
+        # 'When CHECK_ENABLED is falsy, then do not wrap the original function';
 
-        my $code = \&same;
+        subtest 'Useful stacktrace' => sub {
+            result_for test_stacktrace => Int, NonEmptyStr;
+            sub test_stacktrace { Carp::confess('hello') }
 
-        require Sub::Util;
-        my $name = Sub::Util::subname($code);
-        is $name, 'main::same';
+            eval { my ($data, $err) = test_stacktrace() };
 
-        my $proto = Sub::Util::prototype($code);
-        is $proto, ';$';
+            my $file = __FILE__;
+            like $@, qr!hello at $file line!;
+            like $@, qr/main::test_stacktrace\(\) called at $file line /, 'stacktrace includes function name';
+            unlike $@, qr/Result::Simple::/, 'stacktrace does not include Result::Simple by Scope::Upper';
+        };
+
+        subtest 'Same subname and prototype as original' => sub {
+
+            result_for same => Int, NonEmptyStr;
+            sub same (;$) { ok(42) }
+
+            my $code = \&same;
+
+            require Sub::Util;
+            my $name = Sub::Util::subname($code);
+            is $name, 'main::same';
+
+            my $proto = Sub::Util::prototype($code);
+            is $proto, ';$';
+        };
     };
 };
 

--- a/t/synopsis.t
+++ b/t/synopsis.t
@@ -1,11 +1,11 @@
-use Test2::V0;
+use Test2::V0 qw(is done_testing);
 use Test2::Require::Module 'Type::Tiny' => '2.000000';
 use Test2::Require::Module 'kura';
 
 # Enable type check. The default is false.
 BEGIN { $ENV{RESULT_SIMPLE_CHECK_ENABLED} = 1 }
 
-use Result::Simple;
+use Result::Simple qw( ok err result_for );
 use Types::Common -types;
 
 use kura ErrorMessage => StrLength[3,];
@@ -15,21 +15,23 @@ use kura ValidUser    => Dict[name => ValidName, age => ValidAge];
 
 sub validate_name {
     my $name = shift;
-    return Err('No name') unless defined $name;
-    return Err('Empty name') unless length $name;
-    return Err('Reserved name') if $name eq 'root';
-    return Ok($name);
+    return err('No name') unless defined $name;
+    return err('Empty name') unless length $name;
+    return err('Reserved name') if $name eq 'root';
+    return ok($name);
 }
 
 sub validate_age {
     my $age = shift;
-    return Err('No age') unless defined $age;
-    return Err('Invalid age') unless $age =~ /\A\d+\z/;
-    return Err('Too young age') if $age < 18;
-    return Ok($age);
+    return err('No age') unless defined $age;
+    return err('Invalid age') unless $age =~ /\A\d+\z/;
+    return err('Too young age') if $age < 18;
+    return ok($age);
 }
 
-sub new_user :Result(ValidUser, ArrayRef[ErrorMessage]) {
+result_for new_user => ValidUser, ArrayRef[ErrorMessage];
+
+sub new_user {
     my $args = shift;
     my @errors;
 
@@ -39,8 +41,8 @@ sub new_user :Result(ValidUser, ArrayRef[ErrorMessage]) {
     my ($age, $age_err) = validate_age($args->{age});
     push @errors, $age_err if $age_err;
 
-    return Err(\@errors) if @errors;
-    return Ok({ name => $name, age => $age });
+    return err(\@errors) if @errors;
+    return ok({ name => $name, age => $age });
 }
 
 my ($user1, $err1) = new_user({ name => 'taro', age => 42 });


### PR DESCRIPTION
This pull requests produces these things:

1. Rename `Ok`,`Err` to `ok`,`err`
2. Remove :Result attribute, Added `result_for` function
3. Use @EXPORT_OK to export `ok`, `err` and `result_for`
4. Change default value of `$ENV{RESULT_SIMPLE_CHECK_ENABLED}`
5. Added unsafe_unwrap, unsafe_unwrap_err
6. Added alias features

## 1. Rename `Ok`,`Err` to `ok`,`err`

I think `Ok` and `Err` does not align perl conventions. In perl, we usually use snake case. So I renamed function names.

## 2. Remove :Result attribute, Added `result_for` function

It is hard to control attribute and it has bugs like this:

```perl
use Result::Simple qw(ok err); # => It fails to import :Result attribute
```

So, I added `result_for` function, it is simple wrapper for function:

```perl
result_for div => Int, ErrorMessage;

sub div {
   my ($x, $y) = @_;
   if ($y == 0) {
      return err("Division by zero");
   }
  return ok ($x / $y);
}
```

## 3. Use @EXPORT_OK to export `ok`, `err` and `result_for`

It would be better to specify which functions are to be imported.

##  4. Change default value of `$ENV{RESULT_SIMPLE_CHECK_ENABLED}`

Changed to check values by default. Whatever the initial value, it is better to specify this environment variable in the production environment to prevent unexpected accidents.

## 5. Added unsafe_unwrap, unsafe_unwrap_err

These are utility  test  functions.

## 6. Added alias features

```perl
use Result::Simple 
   ok => { -as => 'left' },
   err => { -as => 'right' };
```
